### PR TITLE
Do not transform template strings to regular strings if parent is function call

### DIFF
--- a/lua/puppeteer.lua
+++ b/lua/puppeteer.lua
@@ -38,7 +38,7 @@ function M.templateStr()
 	elseif node:type() == "template_string" then
 		local parent = node:parent()
 		if parent:type() == "call_expression" then return end
-		
+
 		strNode = node
 		isTemplateStr = true
 	else

--- a/lua/puppeteer.lua
+++ b/lua/puppeteer.lua
@@ -36,6 +36,9 @@ function M.templateStr()
 		strNode = node:parent()
 		isTemplateStr = false
 	elseif node:type() == "template_string" then
+		local parent = node:parent()
+		if parent:type() == "call_expression" then return end
+		
 		strNode = node
 		isTemplateStr = true
 	else


### PR DESCRIPTION
Checks if parent of template string is a function call. 
This allows avoiding unwanted behavior when editing a graphql query using graphql-tag, for example:

```typescript
const query = gql`
  query {}
`;
```

This applies to any tagged template literal.

Might need some testing :)