### PR TITLE
fix(pythonFStr): do not expand if whitespace between braces

### DIFF
--- a/lua/puppeteer.lua
+++ b/lua/puppeteer.lua
@@ -88,7 +88,7 @@ function M.pythonFStr()
 	-- rf -> raw-formatted-string
 	local isFString = text:find("^f") or text:find("^rf")
 	-- braces w/ non-digit (not matching regex `{3,}`), see #12
-	local hasBraces = text:find("{.-[^%d,].-}")
+	local hasBraces = text:find("{[^%s].-[^%d,%s].-}")
 
 	if not isFString and hasBraces then
 		text = "f" .. text


### PR DESCRIPTION
Currently the f-string expands if there is whitespace in between the braces, which is likely not when the user intends to use f-strings. The current pattern breaks docstrings containing braces, e.g. a docstring describing an object or json.

It's a slight compromise, as whitespace in braces would not result in an invalid f-string, but this seems to me the more sensible handling.

This would also partially resolve #9.